### PR TITLE
Oppdaterte navnet på elementet som skal holde signaturen

### DIFF
--- a/eksempler/sdpFeil.xml
+++ b/eksempler/sdpFeil.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-feil.xsd ">
 
-	<signatur>
+	<Signature>
       <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
         <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
         <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
@@ -48,7 +48,7 @@
 	      </X509Certificate>
 	      </X509Data>
       </KeyInfo>
-	</signatur>
+	</Signature>
 
 	<tidspunkt>2014-05-19T12:00:00</tidspunkt>
 	<feiltype>KLIENT</feiltype>

--- a/eksempler/sdpKvittering-aapnetAvMottaker.xml
+++ b/eksempler/sdpKvittering-aapnetAvMottaker.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-kvittering.xsd ">
 
-  <signatur>
+  <Signature>
       <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
         <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
         <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
@@ -48,7 +48,7 @@
 	      </X509Certificate>
 	      </X509Data>
       </KeyInfo>
-  </signatur>
+  </Signature>
 
   <tidspunkt>2014-05-19T12:00:00</tidspunkt>
   <aapning/>

--- a/eksempler/sdpKvittering-levertTilPostkasse.xml
+++ b/eksempler/sdpKvittering-levertTilPostkasse.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-kvittering.xsd ">
 
-	<signatur>
+	<Signature>
       <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
         <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
         <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
@@ -48,7 +48,7 @@
 	      </X509Certificate>
 	      </X509Data>
       </KeyInfo>
-	</signatur>
+	</Signature>
 
 	<tidspunkt>2014-05-19T12:00:00</tidspunkt>
 	<levering/>

--- a/eksempler/sdpKvittering-mottakerVarselFeilet.xml
+++ b/eksempler/sdpKvittering-mottakerVarselFeilet.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-kvittering.xsd ">
 
-    <signatur>
+    <Signature>
       <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
         <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
         <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
@@ -48,7 +48,7 @@
 	      </X509Certificate>
 	      </X509Data>
       </KeyInfo>
-    </signatur>
+    </Signature>
 
 	<tidspunkt>2014-05-19T12:00:00</tidspunkt>
 

--- a/eksempler/sdpKvittering-tilbaketrekking.xml
+++ b/eksempler/sdpKvittering-tilbaketrekking.xml
@@ -2,7 +2,7 @@
 <kvittering xmlns="http://begrep.difi.no/sdp/schema_v10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-kvittering.xsd ">
 
 	
-	<signatur>
+	<Signature>
 		<SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
 			<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
 			<SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
@@ -45,7 +45,7 @@
 				</X509Certificate>
 			</X509Data>
 		</KeyInfo>
-	</signatur>
+	</Signature>
 
 	<tidspunkt>2014-05-19T12:00:00</tidspunkt>
 	<tilbaketrekking>

--- a/eksempler/sdpMelding-digital.xml
+++ b/eksempler/sdpMelding-digital.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-melding.xsd ">
 
 
-    <signatur>
+    <Signature>
       <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
         <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
         <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
@@ -52,7 +52,7 @@
 	      </X509Certificate>
 	      </X509Data>
       </KeyInfo>
-    </signatur>
+    </Signature>
 
 	<avsender>
 		<organisasjon>9908:123456789</organisasjon>

--- a/eksempler/sdpMelding-print.xml
+++ b/eksempler/sdpMelding-print.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-melding.xsd ">
 
 	
-	<signatur>
+	<Signature>
 	    <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
 	      <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
 	      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
@@ -52,7 +52,7 @@
 	     </X509Certificate>
 	     </X509Data>
 	    </KeyInfo>
-	</signatur>
+	</Signature>
 
 	<avsender>
 		<organisasjon>9908:123123123</organisasjon>

--- a/xsd/sdp-felles.xsd
+++ b/xsd/sdp-felles.xsd
@@ -11,7 +11,7 @@
 
 	<xsd:complexType name="Melding" abstract="true">
 		<xsd:sequence>
-			<xsd:element name="signatur" type="ds:SignatureType" minOccurs="1" maxOccurs="1" />
+			<xsd:element name="Signature" type="ds:SignatureType" minOccurs="1" maxOccurs="1" />
 		</xsd:sequence>
 	</xsd:complexType>
 


### PR DESCRIPTION
Oppdaterer navnet på elementet som holder signaturen til det mer standardiserte Signature. 
Da vil det også stemme overens med det som allerede står her: http://begrep.difi.no/SikkerDigitalPost/utkast/StandardBusinessDocument/Melding/

Derimot er det fremdeles feil i typediagrammet
