### PR TITLE
Rettet feil i XSD. Går bort fra å bruke oppslagstjenestens type til å br...

### DIFF
--- a/eksempler/sdpManifest.xml
+++ b/eksempler/sdpManifest.xml
@@ -1,27 +1,15 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <manifest
 	xmlns="http://begrep.difi.no/sdp/schema_v10"
-	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-	xmlns:difi="http://begrep.difi.no"
-	xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-manifest.xsd ">
 
 	<mottaker>
 		<person>
-			<difi:personidentifikator>17051400000</difi:personidentifikator>
-			<difi:reservasjon>NEI</difi:reservasjon>
-			<difi:status>AKTIV</difi:status>
-			<difi:beskrivelse>difi:beskrivelse</difi:beskrivelse>
-			<difi:Kontaktinformasjon>
-				<difi:Mobiltelefonnummer sistOppdatert="2001-12-31T12:00:00" sistVerifisert="2001-12-31T12:00:00">12345678</difi:Mobiltelefonnummer>
-				<difi:Epostadresse sistOppdatert="2001-12-31T12:00:00" sistVerifisert="2001-12-31T12:00:00">ola@nordmann.no</difi:Epostadresse>
-			</difi:Kontaktinformasjon>
-			<difi:SikkerDigitalPostAdresse>
-				<difi:postkasseadresse>ola.nordmann#0ABC</difi:postkasseadresse>
-				<difi:postkasseleverandoerAdresse>984661185</difi:postkasseleverandoerAdresse>
-			</difi:SikkerDigitalPostAdresse>
-			<difi:X509Certificate>difi:X509Certificate</difi:X509Certificate>
+			<personidentifikator>17051400000</personidentifikator>
+			<postkasseadresse>ola.nordmann#0ABC</postkasseadresse>
+			<mobiltelefonnummer>12345678</mobiltelefonnummer>
+			<epostadresse>ola@nordmann.no</epostadresse>
 		</person>
 	</mottaker>
 

--- a/eksempler/sdpMelding-digital.xml
+++ b/eksempler/sdpMelding-digital.xml
@@ -2,8 +2,6 @@
 <digitalPost
 	xmlns="http://begrep.difi.no/sdp/schema_v10"
 	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-	xmlns:difi="http://begrep.difi.no"
-	xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-melding.xsd ">
 
@@ -62,19 +60,10 @@
 
 	<mottaker>
 		<person>
-			<difi:personidentifikator>17051400000</difi:personidentifikator>
-			<difi:reservasjon>NEI</difi:reservasjon>
-			<difi:status>AKTIV</difi:status>
-			<difi:beskrivelse>difi:beskrivelse</difi:beskrivelse>
-			<difi:Kontaktinformasjon>
-				<difi:Mobiltelefonnummer sistOppdatert="2001-12-31T12:00:00" sistVerifisert="2001-12-31T12:00:00">12345678</difi:Mobiltelefonnummer>
-				<difi:Epostadresse sistOppdatert="2001-12-31T12:00:00" sistVerifisert="2001-12-31T12:00:00">ola@nordmann.no</difi:Epostadresse>
-			</difi:Kontaktinformasjon>
-			<difi:SikkerDigitalPostAdresse>
-				<difi:postkasseadresse>ola.nordmann#0ABC</difi:postkasseadresse>
-				<difi:postkasseleverandoerAdresse>984661185</difi:postkasseleverandoerAdresse>
-			</difi:SikkerDigitalPostAdresse>
-			<difi:X509Certificate>difi:X509Certificate</difi:X509Certificate>
+			<personidentifikator>17051400000</personidentifikator>
+			<postkasseadresse>ola.nordmann#0ABC</postkasseadresse>
+			<mobiltelefonnummer>12345678</mobiltelefonnummer>
+			<epostadresse>ola@nordmann.no</epostadresse>
 		</person>
 	</mottaker>
 

--- a/eksempler/sdpMelding-print.xml
+++ b/eksempler/sdpMelding-print.xml
@@ -1,9 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <digitalPost
 	xmlns="http://begrep.difi.no/sdp/schema_v10"
-	xmlns:difi="http://begrep.difi.no"
 	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-	xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://begrep.difi.no/sdp/schema_v10 ../xsd/sdp-melding.xsd ">
 
@@ -62,19 +60,10 @@
 
 	<mottaker>
 		<person>
-			<difi:personidentifikator>17051400000</difi:personidentifikator>
-			<difi:reservasjon>NEI</difi:reservasjon>
-			<difi:status>AKTIV</difi:status>
-			<difi:beskrivelse>difi:beskrivelse</difi:beskrivelse>
-			<difi:Kontaktinformasjon>
-				<difi:Mobiltelefonnummer sistOppdatert="2001-12-31T12:00:00" sistVerifisert="2001-12-31T12:00:00">12345678</difi:Mobiltelefonnummer>
-				<difi:Epostadresse sistOppdatert="2001-12-31T12:00:00" sistVerifisert="2001-12-31T12:00:00">ola@nordmann.no</difi:Epostadresse>
-			</difi:Kontaktinformasjon>
-			<difi:SikkerDigitalPostAdresse>
-				<difi:postkasseadresse>ola.nordmann#0ABC</difi:postkasseadresse>
-				<difi:postkasseleverandoerAdresse>984661185</difi:postkasseleverandoerAdresse>
-			</difi:SikkerDigitalPostAdresse>
-			<difi:X509Certificate>difi:X509Certificate</difi:X509Certificate>
+			<personidentifikator>17051400000</personidentifikator>
+			<postkasseadresse>ola.nordmann#0ABC</postkasseadresse>
+			<mobiltelefonnummer>12345678</mobiltelefonnummer>
+			<epostadresse>ola@nordmann.no</epostadresse>
 		</person>
 	</mottaker>
 

--- a/xsd/sdp-felles.xsd
+++ b/xsd/sdp-felles.xsd
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://begrep.difi.no/sdp/schema_v10"
 			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-			xmlns:difi="http://begrep.difi.no"
 			xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
             targetNamespace="http://begrep.difi.no/sdp/schema_v10"
             elementFormDefault="qualified" version="1.0">
 
-	<xsd:import namespace="http://begrep.difi.no" schemaLocation="oppslag/oppslagstjeneste-metadata-14-05.xsd"/>
 	<xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="w3/xmldsig-core-schema.xsd"/>
 
 	<xsd:complexType name="Melding" abstract="true">
@@ -45,14 +43,29 @@
 
 	<xsd:complexType name="Mottaker">
 		<xsd:choice>
-			<xsd:element name="person" type="difi:Person"/>
+			<xsd:element name="person" type="Person"/>
 			<xsd:element name="virksomhet" type="Virksomhet"/>
 		</xsd:choice>
 	</xsd:complexType>
 
+	<xsd:complexType name="Person">
+		<xsd:sequence>
+			<xsd:element name="personidentifikator" minOccurs="1" maxOccurs="1">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:pattern value="[0-9]{11}"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:element>
+			<xsd:element name="postkasseadresse" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="mobiltelefonnummer" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="epostadresse" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
 	<xsd:complexType name="Virksomhet">
 		<xsd:sequence>
-			<xsd:element name="sikkerDigitalPostAdresse" type="difi:SikkerDigitalPostAdresse"/>
+			<xsd:element name="postkasseadresse" type="xsd:string" minOccurs="1" maxOccurs="1"/>
 		</xsd:sequence>
 	</xsd:complexType>
 

--- a/xsd/sdp-melding.xsd
+++ b/xsd/sdp-melding.xsd
@@ -2,7 +2,6 @@
 <xsd:schema
 	xmlns="http://begrep.difi.no/sdp/schema_v10"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-	xmlns:difi="http://begrep.difi.no"
 	xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
 	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
 	targetNamespace="http://begrep.difi.no/sdp/schema_v10" elementFormDefault="qualified" version="1.0">
@@ -10,7 +9,6 @@
 	<xsd:include schemaLocation="sdp-felles.xsd"/>
 	<xsd:import namespace="http://www.w3.org/2001/04/xmlenc#" schemaLocation="w3/xenc-schema.xsd"/>
 	<xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="w3/xmldsig-core-schema.xsd"/>
-	<xsd:import namespace="http://begrep.difi.no" schemaLocation="oppslag/oppslagstjeneste-metadata-14-05.xsd"/>
 
 
 	<xsd:element name="digitalPost" type="DigitalPost" />

--- a/xsd/sdp.xsd
+++ b/xsd/sdp.xsd
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema version="1.0" targetNamespace="http://begrep.difi.no/sdp/schema_v10" xmlns="http://begrep.difi.no/sdp/schema_v10" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:difi="http://begrep.difi.no"
+<xsd:schema version="1.0" targetNamespace="http://begrep.difi.no/sdp/schema_v10" xmlns="http://begrep.difi.no/sdp/schema_v10" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	xmlns:enc="http://www.w3.org/2001/04/xmlenc#" xmlns:sawsdl="http://www.w3.org/ns/sawsdl" elementFormDefault="qualified">
 
 	<xsd:import namespace="http://www.w3.org/2001/04/xmlenc#" schemaLocation="w3/xenc-schema.xsd" />
-	<xsd:import namespace="http://begrep.difi.no" schemaLocation="oppslag/oppslagstjeneste-metadata-14-05.xsd" />
 
 	<xsd:include schemaLocation="sdp-feil.xsd"/>
 	<xsd:include schemaLocation="sdp-kvittering.xsd"/>


### PR DESCRIPTION
...uke egen sdp type for mottaker ref dok.

Det fjerner for øvrig siste avhengighet til oppslagstjenestens XSD slik at sdp nå står helt på egne ben. Eksempler er oppdatert. For øvrig har dette også konsekvenser for sdpManifest - se eksempel. 

Fixes difi/begrep-SikkerDigitalPost#69
