### PR TITLE
fra dato til tidspunkt for virkningsdato

### DIFF
--- a/xsd/sdp-melding.xsd
+++ b/xsd/sdp-melding.xsd
@@ -87,7 +87,18 @@
 
 	<xsd:complexType name="DigitalPostInfo">
 		<xsd:sequence>
-			<xsd:element name="virkningsdato" type="xsd:date" minOccurs="0" maxOccurs="1"/>
+			<xsd:choice>
+				<xsd:element name="virkningsdato" type="xsd:date" minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>Dag når en melding tidligst kan gjøres tilgjengelig i innbygger sin postkasse. Posten tilgjengeliggjøres da ved midnatt. Krav til når meldingen er tilgjengeliggjort er beskrevet i kontraktene med Leverandørene.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="virkningstidspunkt" type="xsd:datetime" minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>Dag og Tidspunkt for når en melding tidligst kan gjøres tilgjengelig i innbygger sin postkasse. Krav til når meldingen er tilgjengeliggjort er beskrevet i kontraktene med Leverandørene.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 			<xsd:element name="aapningskvittering" type="xsd:boolean" default="false" minOccurs="0" maxOccurs="1"/>
 			<xsd:element name="sikkerhetsnivaa" type="Sikkerhetsnivaa" minOccurs="1" maxOccurs="1"/>
 			<xsd:element name="ikkeSensitivTittel" minOccurs="1" maxOccurs="1" type="Tittel">


### PR DESCRIPTION
Ref. https://github.com/difi/begrep-SikkerDigitalPost/issues/166

Forslag til endring i grensesnittet for å støtte behovet beskrevet her #166 
Endringer er ikke bakoverkompatible og vil kreve endringer hos alle klienter, i tillegg må postkasseleverandørene leve med to XSD'r.

Alternativt kan man tenke seg å legge inn en <choice> der Avsender kan velge mellom å bruke virkningsdato eller virkningstidspunkt
