### PR TITLE
Støtte for lenke utenfor brev

### DIFF
--- a/eksempler/sdpManifest.xml
+++ b/eksempler/sdpManifest.xml
@@ -31,7 +31,7 @@
 
 	<lenke>
 		<url>https://www.avsender.no/svar</url>
-        <beskrivelse lang="no">Vennligst svar på denne viktige meldingen for videre saksbehandling.</beskrivelse>
+		<beskrivelse lang="no">Vennligst svar på denne viktige meldingen for videre saksbehandling.</beskrivelse>
 		<knappTekst lang="no">Svar på den viktige meldingen</knappTekst>
 		<frist>2017-10-01T12:00:00+02:00</frist>
 	</lenke>


### PR DESCRIPTION
Viser til dialog mellom Difi og Posten ved Martin Koksrud Bekkelund.

---

Innfører et frivillig elementet for å formidle en lenke til innbyggers
postkasse. Lenken inneholder alltid en http(s)-adresse (`url`) som blir
presentert til innbygger i postkassen.

Avsender kan i tillegg sende med noen frivillige elementer:

- `beskrivelse`: tekstlig beskrivelse som vises for innbyggeren.
- `knappTekst`: tekst på knappen som vises i postkassen. Postkasse-
leverandøren kan vise en standard-tekst dersom dette elementet mangler.
- `frist`: tidspunkt for når lenken «går ut på dato». Lenken vil aldri
gå ut på dato dersom elementet mangler.

