### PR TITLE
Støtte for valgfri strukturert data knyttet til et dokument

### DIFF
--- a/xsd/sdp-manifest.xsd
+++ b/xsd/sdp-manifest.xsd
@@ -32,6 +32,15 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+            <xsd:element name="data" minOccurs="0" maxOccurs="1" type="DokumentData">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Ekstra data som beriker dokumentet i postkassen.
+                        Se https://begrep.difi.no/SikkerDigitalPost/utvidelser for en oversikt over hvilke utvidelser
+                        som finnes og er tilgjengelig hos de ulike postkasseleverandørene.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
 		</xsd:sequence>
 		<xsd:attribute name="href" use="required">
 			<xsd:annotation>
@@ -103,5 +112,34 @@
 			<xsd:maxLength value="30"/>
 		</xsd:restriction>
 	</xsd:simpleType>
+
+    <xsd:complexType name="DokumentData">
+        <xsd:attribute name="href" use="required">
+            <xsd:annotation>
+                <xsd:documentation>
+                    Navn på filen i dokumentpakken.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="4" />
+                    <xsd:maxLength value="100" />
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
+        <xsd:attribute name="mime" use="required">
+            <xsd:annotation>
+                <xsd:documentation>
+                    For tillatte MIME-typer, se https://begrep.difi.no/SikkerDigitalPost/utvidelser
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1" />
+                    <xsd:maxLength value="100" />
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
+    </xsd:complexType>
 
 </xsd:schema>


### PR DESCRIPTION
Viser til diskusjon på #201 og endring PK-0017.

---

Innfører et frivillig element `<data>` som kan knytte en fil med
strukturerte data til et hoveddokument eller vedlegg.

Elementet kan f. eks. se slik ut for en tenkt datatype «lenke»:

```xml
<data​ ​href="lenke.xml"
      mime="application/vnd.difi.dpi.lenke+xml" />
```

`lenke.xml` inneholder dermed XML som definerer en lenke hvis data vises
i postkassen _utenfor_ dokumentet dataen er knyttet til dersom
postkasseleverandøren til innbyggeren støtter denne datatypen.
XMLen må validere i henhold til en separat XSD, men innføring
av nye XSDer er utenfor scopet til denne pull requesten.