### PR TITLE
XSD-forslag til datatypen «Lenke»

### DIFF
--- a/eksempler/utvidelser/lenke.xml
+++ b/eksempler/utvidelser/lenke.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lenke xmlns="http://begrep.difi.no/sdp/utvidelser/lenke"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://begrep.difi.no/sdp/utvidelser/lenke ../../xsd/utvidelser/lenke.xsd">
+    <url>https://www.avsender.no/svar</url>
+    <beskrivelse lang="no">Vennligst svar på denne viktige meldingen for videre saksbehandling.</beskrivelse>
+    <knappTekst lang="no">Svar på den viktige meldingen</knappTekst>
+    <frist>2017-10-01T12:00:00+02:00</frist>
+</lenke>

--- a/eksempler/validate.sh
+++ b/eksempler/validate.sh
@@ -19,6 +19,7 @@ for eksempel in ${eksempler}/sbdh.xml; do
   validate ${eksempel} ${xsds}/SBDH20040506-02/StandardBusinessDocumentHeader.xsd || ((errors++))
 done
 
+validate ${eksempler}/utvidelser/lenke.xml ${xsds}/utvidelser/lenke.xsd || ((errors++))
 
 if (( errors > 0 )); then
   echo Fant ${errors} filer med valideringsfeil!

--- a/xsd/utvidelser/lenke.xsd
+++ b/xsd/utvidelser/lenke.xsd
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema version="1.0" targetNamespace="http://begrep.difi.no/sdp/utvidelser/lenke"
+            xmlns="http://begrep.difi.no/sdp/utvidelser/lenke"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified">
+
+    <xsd:element name="lenke" type="Lenke"/>
+
+    <xsd:complexType name="Lenke">
+        <xsd:sequence>
+            <xsd:element name="url" type="HttpLenke" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="beskrivelse" type="LenkeBeskrivelseTekst" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="knappTekst" type="LenkeKnappTekst" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="frist" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:simpleType name="HttpLenke">
+        <xsd:restriction base="xsd:anyURI">
+            <xsd:pattern value="https?://.+"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="LenkeBeskrivelseTekst">
+        <xsd:simpleContent>
+            <xsd:extension base="LenkeBeskrivelseTekstString">
+                <xsd:attribute name="lang" type="Spraakkode" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:simpleType name="LenkeBeskrivelseTekstString">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="1"/>
+            <xsd:maxLength value="70"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="LenkeKnappTekst">
+        <xsd:simpleContent>
+            <xsd:extension base="LenkeKnappTekstString">
+                <xsd:attribute name="lang" type="Spraakkode" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:simpleType name="LenkeKnappTekstString">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="1"/>
+            <xsd:maxLength value="30"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="Spraakkode">
+        <xsd:annotation>
+            <xsd:documentation>
+                Språkkode ihht ISO-639-1 (2 bokstaver)
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="2"/>
+            <xsd:maxLength value="2"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+</xsd:schema>


### PR DESCRIPTION
For at Difi skal kunne teste PK-0017 ser Posten det som en nødvendighet at vi innfører en datatype. Hvis dette ikke gjøres, kan Difi bare verifisere at postkasseleverandørene aksepterer meldinger som inneholder datatyper som _ikke_ støttes. 

Foreslår at lenke utenfor brev etableres som første datatype, siden begge postkasseleverandørene allerede støtter denne funksjonaliteten (jfr. #203 ). 

I følge PK-0017 skal pull requests som foreslår nye datatyper inneholde XSD, mime-type og dokumentasjon. Posten foreslår mime-type `application/vnd.difi.dpi.lenke+xml`. Hvis Difi er enig i at det er en god idé å innføre denne datatypen, oppdaterer jeg denne pull requesten med dokumentasjon.

Type-definisjonen er kopiert fra sdp-manifest.xsd og er dermed identisk
med eksisterende definisjon av lenke utenfor brev.

Bør sees i sammenheng med #204 .