### PR TITLE
Generell dokumentasjon for utvidelser + lenke utenfor brev

### DIFF
--- a/begrep/Dokument.textile
+++ b/begrep/Dokument.textile
@@ -25,6 +25,7 @@ table(table table-striped).
 | href| 1..1 | xsd:string |
 | mime | 1..1 |  xsd:string  |
 | "Tittel":Tittel | 0..1 | "Tittel":Tittel |
+| "Data":DokumentData | 0..1| "DokumentData":DokumentData |
 
 h4. Xml eksempel
 

--- a/begrep/DokumentData.textile
+++ b/begrep/DokumentData.textile
@@ -1,0 +1,32 @@
+---
+layout: egenskap
+title: DokumentData
+headtitle: Begrepskatalog for Sikker digital post -
+group: complexType
+
+name: DokumentData
+prev: Begreper
+---
+
+{% include variables.html %}
+
+- Identifikator := "{{ pageUrlMinor }}":{{ pageUrlMinor }}
+- Term := {{page.title}}
+- Definisjon := Strukturert data for beriket visning i innbyggers postkasse
+- Datatype := complexType
+- Kjelde := DIFI
+
+h4. Eigenskapar
+
+table(table table-striped).
+|_. Identifikator |_. Kardinalitet |_. Datatype |_. Beskrivelse |
+| href| 1..1 | xsd:string | Filnavn på data-dokumentet i dokumentpakken |
+| mime | 1..1 |  xsd:string  | Utvidelsens mime-type. "Tilgjengelig utvidelser":/forretningslag/Utvidelser |
+
+h4. Xml eksempel
+
+<pre class="brush: xml; toolbar: false">
+
+<data href="lenke.xml" mime="application/vnd.difi.dpi.lenke+xml" />
+
+</pre>

--- a/forretningslag/Sikkerhet/index.textile
+++ b/forretningslag/Sikkerhet/index.textile
@@ -6,7 +6,7 @@ group: forretningslag
 
 id: Forretningslag/Sikkerhet
 
-next: utskrift
+next: Forretningslag/Utvidelser
 
 ---
 

--- a/forretningslag/Utvidelser/Lenke.textile
+++ b/forretningslag/Utvidelser/Lenke.textile
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Lenke utenfor brev
+headtitle: Sikker digital post - Lenke utenfor brev
+group: forretningslag
+
+id: Forretningslag/Utvidelser/Lenke
+next: utskrift
+
+---
+
+- Definisjon := Lenke utenfor brev
+- Mime-Type := application/vnd.difi.dpi.lenke+xml
+- Datatype := complexType
+- Kommentar := Definerer en lenke som presenteres for innbygger i postkassen. Postkasseleverandøren kan vise en standard beskrivelse og tekst på knappen dersom de ikke er definert.
+- XSD := https://begrep.difi.no/SikkerDigitalPost/xsd/utvidelser/lenke.xsd
+
+h3. Attributer
+
+table(table table-striped).
+|_. Identifikator |_. Kardinalitet |_. Datatype |
+| url | 1..1 | HttpLenke |
+| beskrivelse | 0..1 | LenkeBeskrivelseTekst |
+| knappTekst | 0..1 | LenkeKnappTekst |
+| frist | 0..1 | xsd:dateTime |
+
+h3. Eksempel
+
+<lenke>
+    <url>https://www.avsender.no/svar</url>
+    <beskrivelse lang="no">Vennligst svar på denne viktige meldingen for videre saksbehandling.</beskrivelse>
+    <knappTekst lang="no">Svar på den viktige meldingen</knappTekst>
+    <frist>2017-10-01T12:00:00+02:00</frist>
+</lenke>

--- a/forretningslag/Utvidelser/index.textile
+++ b/forretningslag/Utvidelser/index.textile
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Utvidelser
+headtitle: Sikker digital post - Utvidelser
+group: forretningslag
+
+id: Forretningslag/Utvidelser
+next: Forretningslag/Utvidelser/Lenke
+
+children:
+ - name: Forretningslag/Utvidelser/Lenke
+
+---
+
+h2. Introduksjon
+
+Postkasseleverandørene støtter ulike verdiøkende tjeneste utover det som er definert i "Dokumentpakken":Dokumentpakke. En utvidelse er knyttet til ett dokument og tilfører en beriket visning i innbyggers postkasse.
+
+For å knytte en utvidelse til et dokument må det inkluderes en fil ihht. utvidelsens XML-schema (XSD) i dokumentpakken, og det aktuelle "dokumentet":../../Dokument refererer til «"data-dokumentet":../../DokumentData» vha. @<data>@-elementet i "manifestet":../Dokumentpakke/Manifest.
+
+Dersom innbyggers postkasseleverandør ikke støtter utvidelsen blir informasjonen forkastet av postkassen uten at hverken avsender eller innbygger får beskjed om dette.
+
+Tabellen nedenfor viser alle tilgjengelige utvidelser og hvilke av postkasseleverandørene som støtter de ulike.
+
+h3. Utvidelser
+
+table(table table-striped).
+|_. Fil |_. Mime-Type |_. Digipost |_. e-Boks |
+| "Lenke utenfor brev":Lenke | @application/vnd.difi.dpi.lenke+xml@ | Ja | Ja

--- a/index.textile
+++ b/index.textile
@@ -10,6 +10,7 @@ children:
  - name: Oversikt
  - name: Forretningslag
  - name: Forretningslag/Dokumentpakke
+ - name: Forretningslag/Utvidelser
  - name: utskrift
  - name: Forretningsmeldinger
  - name: Forretningslag/StandardBusinessDocument
@@ -47,6 +48,7 @@ table(table table-striped).
 | "Oversikt":innledning/ | Mer om sikker digital post og generelle aspekter ved løsningen |
 | "Forretningslag":forretningslag/ | Aktører, prosesser og overordnet meldingsstruktur/format |
 | "Dokumentpakke":forretningslag/Dokumentpakke | Oppbygging av selve dokumentpakken som skal til mottaker |
+| "Utvidelser":forretningslag/Utvidelser | Utvidelser som beriker dokumenter i innbyggers postkasse |
 | "Utskrift og forsendelse":utskrift/ | Mer om utskriftstjenesten knyttet til digital post |
 | "Forretningsmeldinger":meldinger/ | Oppbygging av forretningsinformasjonen for behandling av dokumentpakken |
 | "Standard Business Document":forretningslag/StandardBusinessDocument | Informasjon relatert til ruting og håndtering av forretningsmeldingen |


### PR DESCRIPTION
Hei.

Denne PRen inneholder generell dokumentasjon for utvidelser («data-dokumenter») og dokumentasjon for den første data-typen (lenke utenfor brev).

Jeg så i [begrepskatalogen](https://begrep.difi.no/README) at det skal finnes et Vagrant-script for å starte den på lokal datamaskin, men jeg fant ikke dette i repositoriet. Jeg har derfor ikke fått til å kjøre begrepskatalogen og verifisert at sidene renderes riktig. Ber om at Difi verifiserer at endringen ser OK ut før det merges, eller tilgjengeliggjør en mulighet for å kjøre det opp slik at jeg kan verifisere det selv.