### PR TITLE
Gjør FysiskPostType frivillig

### DIFF
--- a/xsd/sdp-melding.xsd
+++ b/xsd/sdp-melding.xsd
@@ -210,7 +210,7 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="posttype" type="FysiskPostType" minOccurs="1" maxOccurs="1" />
+			<xsd:element name="posttype" type="FysiskPostType" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="utskriftsfarge" type="Utskriftsfarge" minOccurs="1" maxOccurs="1" />
 			<xsd:element name="retur" type="FysiskPostRetur" minOccurs="1" maxOccurs="1" >
 				<xsd:annotation>


### PR DESCRIPTION
I forbindelse med at A- og B-post ikke er begreper som skal brukes om fysisk post så bør elementet `FysiskPostType` gjøres frivillig.