### PR TITLE
Fikser noen syntax-feil i dokumentasjonen for utvidelser

### DIFF
--- a/forretningslag/Utvidelser/Lenke.textile
+++ b/forretningslag/Utvidelser/Lenke.textile
@@ -26,9 +26,11 @@ table(table table-striped).
 
 h3. Eksempel
 
+<pre class="brush: xml; toolbar: false">
 <lenke>
     <url>https://www.avsender.no/svar</url>
     <beskrivelse lang="no">Vennligst svar på denne viktige meldingen for videre saksbehandling.</beskrivelse>
     <knappTekst lang="no">Svar på den viktige meldingen</knappTekst>
     <frist>2017-10-01T12:00:00+02:00</frist>
 </lenke>
+</pre>

--- a/forretningslag/Utvidelser/index.textile
+++ b/forretningslag/Utvidelser/index.textile
@@ -16,7 +16,7 @@ h2. Introduksjon
 
 Postkasseleverandørene støtter ulike verdiøkende tjeneste utover det som er definert i "Dokumentpakken":Dokumentpakke. En utvidelse er knyttet til ett dokument og tilfører en beriket visning i innbyggers postkasse.
 
-For å knytte en utvidelse til et dokument må det inkluderes en fil ihht. utvidelsens XML-schema (XSD) i dokumentpakken, og det aktuelle "dokumentet":../../Dokument refererer til «"data-dokumentet":../../DokumentData» vha. @<data>@-elementet i "manifestet":../Dokumentpakke/Manifest.
+For å knytte en utvidelse til et dokument må det inkluderes en fil ihht. utvidelsens XML-schema (XSD) i dokumentpakken, og det aktuelle "dokumentet":../../begrep/Dokument refererer til "«data-dokumentet»":../../begrep/DokumentData vha. @<data>@-elementet i "manifestet":../Dokumentpakke/Manifest.
 
 Dersom innbyggers postkasseleverandør ikke støtter utvidelsen blir informasjonen forkastet av postkassen uten at hverken avsender eller innbygger får beskjed om dette.
 
@@ -26,4 +26,4 @@ h3. Utvidelser
 
 table(table table-striped).
 |_. Fil |_. Mime-Type |_. Digipost |_. e-Boks |
-| "Lenke utenfor brev":Lenke | @application/vnd.difi.dpi.lenke+xml@ | Ja | Ja
+| "Lenke utenfor brev":Lenke | @application/vnd.difi.dpi.lenke+xml@ | Ja | Ja |


### PR DESCRIPTION
Oppdaget noen syntax-feil i [arbeidsversjonen](https://begrep.difi.no/SikkerDigitalPost/utkast/) av begrepskatalogen:

### På [Utvidelser](https://begrep.difi.no/SikkerDigitalPost/utkast/forretningslag/Utvidelser/)-siden
- To døde lenker
- Feil formattering på tabellen som viser hvilke postkasser som støtter de ulike datatypene

### På [Lenke utenfor brev](https://begrep.difi.no/SikkerDigitalPost/utkast/forretningslag/Utvidelser/Lenke)-siden
- Feil visning av XML-eksempel