### PR TITLE
Fjerner `DOCTYPE` fra w3 XSD-filer

### DIFF
--- a/xsd/w3/exc-c14n.xsd
+++ b/xsd/w3/exc-c14n.xsd
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE schema
-	PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "XMLSchema.dtd"
-	[
-		<!ATTLIST schema
-			xmlns:ec CDATA #FIXED 'http://www.w3.org/2001/10/xml-exc-c14n#'>
-		<!ENTITY ec 'http://www.w3.org/2001/10/xml-exc-c14n#'>
-		<!ENTITY % p ''>
-		<!ENTITY % s ''>
-		]>
-
-
 <!-- Schema for Exclusive Canonicalization
     http://www.w3.org/2001/10/xml-exc-c14n#
     $Revision: 1.1 $ on $Date: 2002/07/11 17:26:47 $ by $Author: reagle $

--- a/xsd/w3/xenc-schema.xsd
+++ b/xsd/w3/xenc-schema.xsd
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE schema  PUBLIC "-//W3C//DTD XMLSchema 200102//EN"
- "XMLSchema.dtd"
- [
-   <!ATTLIST schema
-     xmlns:xenc CDATA #FIXED 'http://www.w3.org/2001/04/xmlenc#'
-     xmlns:ds CDATA #FIXED 'http://www.w3.org/2000/09/xmldsig#'>
-   <!ENTITY xenc 'http://www.w3.org/2001/04/xmlenc#'>
-   <!ENTITY % p ''>
-   <!ENTITY % s ''>
-  ]>
-
 <schema xmlns='http://www.w3.org/2001/XMLSchema' version='1.0'
         xmlns:xenc='http://www.w3.org/2001/04/xmlenc#'
         xmlns:ds='http://www.w3.org/2000/09/xmldsig#'

--- a/xsd/w3/xmldsig-core-schema.xsd
+++ b/xsd/w3/xmldsig-core-schema.xsd
@@ -1,14 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE schema
-  PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "XMLSchema.dtd"
- [
-   <!ATTLIST schema
-     xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
-   <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
-   <!ENTITY % p ''>
-   <!ENTITY % s ''>
-  ]>
-
 <!-- Schema for XML Signatures
     http://www.w3.org/2000/09/xmldsig#
     $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $


### PR DESCRIPTION
Nyere versjoner av Spring Web Services har blitt strengere på dette
etter å ha vært sårbar mot XML External Entity Injection (XXE)